### PR TITLE
Fix(#3): use defaultOptions on mount

### DIFF
--- a/src/Barcode.svelte
+++ b/src/Barcode.svelte
@@ -30,7 +30,7 @@
 
   onMount(async () => {
     await tick();
-    JsBarcode(barcode, value, optionsOA);
+    JsBarcode(barcode, value, defaultOptions);
   });
 
   afterUpdate(async () => {


### PR DESCRIPTION
Fixes #3 by passing in `defaultOptions` on mount.

Another option would be to remove the options parameter on mount because the options parameter is nullable.