### PR TITLE
Added the ability to pass alt text for the img version of the barcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ yarn add svelte-barcode --save
       <td>Overide the text that is diplayed</td>
     </tr>
     <tr>
+      <td>altText</td>
+      <td>string?</td>
+      <td>value prop</td>
+      <td>❌</td>
+      <td>Overide the alt text for an img barcode.</td>
+    </tr>
+    <tr>
       <td>fontOptions</td>
       <td>string?</td>
       <td><code>''</code></td>

--- a/src/Barcode.svelte
+++ b/src/Barcode.svelte
@@ -40,7 +40,7 @@
 </script>
 
 {#if elementTag === 'img'}
-  <img bind:this={barcode} alt="" />
+	<img bind:this={barcode} alt="{options.altText || value}" />
 {:else if elementTag === 'canvas'}
   <canvas bind:this={barcode}></canvas>
 {:else}


### PR DESCRIPTION
altText key can be added to options to specify what alt text to show for the image. The default value is the same as the value prop passed.